### PR TITLE
feat: implement scan storage with REST API and H2 database

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -58,7 +58,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>  <!-- Latest stable version -->
+        </dependency>
 
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.1.Final</version>
+        </dependency>
 
     </dependencies>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -69,6 +69,13 @@
             <artifactId>hibernate-validator</artifactId>
             <version>8.0.1.Final</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.24</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/backend/src/main/java/kg16/demo/dto/ScanDTO.java
+++ b/backend/src/main/java/kg16/demo/dto/ScanDTO.java
@@ -3,7 +3,15 @@ package kg16.demo.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ScanDTO {
 
     @NotBlank
@@ -19,56 +27,4 @@ public class ScanDTO {
     private Integer status;
 
     private Timestamp lastSeen;
-
-    // Constructor
-    public ScanDTO() {}
-
-    public ScanDTO(String hostname, String ipAddress, String macAddress, Integer status, Timestamp lastSeen) {
-        this.hostname = hostname;
-        this.ipAddress = ipAddress;
-        this.macAddress = macAddress;
-        this.status = status;
-        this.lastSeen = lastSeen;
-    }
-
-    // Getters and Setters
-    public String getHostname() {
-        return hostname;
-    }
-
-    public void setHostname(String hostname) {
-        this.hostname = hostname;
-    }
-
-    public String getIpAddress() {
-        return ipAddress;
-    }
-
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-    }
-
-    public String getMacAddress() {
-        return macAddress;
-    }
-
-    public void setMacAddress(String macAddress) {
-        this.macAddress = macAddress;
-    }
-
-    public Integer getStatus() {
-        return status;
-    }
-
-    public void setStatus(Integer status) {
-        this.status = status;
-    }
-
-    public Timestamp getLastSeen() {
-        return lastSeen;
-    }
-
-    public void setLastSeen(Timestamp lastSeen) {
-        this.lastSeen = lastSeen;
-    }
 }

--- a/backend/src/main/java/kg16/demo/dto/ScanDTO.java
+++ b/backend/src/main/java/kg16/demo/dto/ScanDTO.java
@@ -1,0 +1,74 @@
+package kg16.demo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.sql.Timestamp;
+
+public class ScanDTO {
+
+    @NotBlank
+    private String hostname;
+
+    @NotBlank
+    private String ipAddress;
+
+    @NotBlank
+    private String macAddress;
+
+    @NotNull
+    private Integer status;
+
+    private Timestamp lastSeen;
+
+    // Constructor
+    public ScanDTO() {}
+
+    public ScanDTO(String hostname, String ipAddress, String macAddress, Integer status, Timestamp lastSeen) {
+        this.hostname = hostname;
+        this.ipAddress = ipAddress;
+        this.macAddress = macAddress;
+        this.status = status;
+        this.lastSeen = lastSeen;
+    }
+
+    // Getters and Setters
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Timestamp getLastSeen() {
+        return lastSeen;
+    }
+
+    public void setLastSeen(Timestamp lastSeen) {
+        this.lastSeen = lastSeen;
+    }
+}

--- a/backend/src/main/java/kg16/demo/dto/ScanResponse.java
+++ b/backend/src/main/java/kg16/demo/dto/ScanResponse.java
@@ -1,0 +1,9 @@
+package kg16.demo.dto;
+
+import java.time.Instant;
+
+public record ScanResponse(
+    String message,
+    String macAddress,
+    Instant timestamp
+) {}

--- a/backend/src/main/java/kg16/demo/model/Scan.java
+++ b/backend/src/main/java/kg16/demo/model/Scan.java
@@ -1,0 +1,95 @@
+package kg16.demo.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "Scans") 
+public class Scan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long deviceId;
+
+    @JsonProperty("hostname")
+    @Column(name = "hostname", nullable = false)
+    private String hostname;
+
+    @JsonProperty("ipAddress") 
+    @Column(name = "ip_address", nullable = false)
+    private String ipAddress;
+
+    @JsonProperty("macAddress") 
+    @Column(name = "mac_address", nullable = false, unique = true)
+    private String macAddress;
+
+    @JsonProperty("status") 
+    @Column(name = "status", nullable = false)
+    private Integer status;
+
+    @JsonProperty("lastSeen") 
+    @Column(name = "last_seen", nullable = false)
+    private Timestamp lastSeen;
+
+    // Empty constructor (required by JPA)
+    public Scan() {}
+
+    // Constructor
+    public Scan(String hostname, String ipAddress, String macAddress, Integer status, Timestamp lastSeen) {
+        this.hostname = hostname;
+        this.ipAddress = ipAddress;
+        this.macAddress = macAddress;
+        this.status = status;
+        this.lastSeen = lastSeen;
+    }
+
+    // Getters and Setters
+    public Long getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(Long deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Timestamp getLastSeen() {
+        return lastSeen;
+    }
+
+    public void setLastSeen(Timestamp lastSeen) {
+        this.lastSeen = lastSeen;
+    }
+}

--- a/backend/src/main/java/kg16/demo/model/Scan.java
+++ b/backend/src/main/java/kg16/demo/model/Scan.java
@@ -3,9 +3,17 @@ package kg16.demo.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 @Entity
-@Table(name = "Scans") 
+@Table(name = "Scans")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Scan {
 
     @Id
@@ -16,80 +24,19 @@ public class Scan {
     @Column(name = "hostname", nullable = false)
     private String hostname;
 
-    @JsonProperty("ipAddress") 
+    @JsonProperty("ipAddress")
     @Column(name = "ip_address", nullable = false)
     private String ipAddress;
 
-    @JsonProperty("macAddress") 
+    @JsonProperty("macAddress")
     @Column(name = "mac_address", nullable = false, unique = true)
     private String macAddress;
 
-    @JsonProperty("status") 
+    @JsonProperty("status")
     @Column(name = "status", nullable = false)
     private Integer status;
 
-    @JsonProperty("lastSeen") 
+    @JsonProperty("lastSeen")
     @Column(name = "last_seen", nullable = false)
     private Timestamp lastSeen;
-
-    // Empty constructor (required by JPA)
-    public Scan() {}
-
-    // Constructor
-    public Scan(String hostname, String ipAddress, String macAddress, Integer status, Timestamp lastSeen) {
-        this.hostname = hostname;
-        this.ipAddress = ipAddress;
-        this.macAddress = macAddress;
-        this.status = status;
-        this.lastSeen = lastSeen;
-    }
-
-    // Getters and Setters
-    public Long getDeviceId() {
-        return deviceId;
-    }
-
-    public void setDeviceId(Long deviceId) {
-        this.deviceId = deviceId;
-    }
-
-    public String getHostname() {
-        return hostname;
-    }
-
-    public void setHostname(String hostname) {
-        this.hostname = hostname;
-    }
-
-    public String getIpAddress() {
-        return ipAddress;
-    }
-
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-    }
-
-    public String getMacAddress() {
-        return macAddress;
-    }
-
-    public void setMacAddress(String macAddress) {
-        this.macAddress = macAddress;
-    }
-
-    public Integer getStatus() {
-        return status;
-    }
-
-    public void setStatus(Integer status) {
-        this.status = status;
-    }
-
-    public Timestamp getLastSeen() {
-        return lastSeen;
-    }
-
-    public void setLastSeen(Timestamp lastSeen) {
-        this.lastSeen = lastSeen;
-    }
 }

--- a/backend/src/main/java/kg16/demo/repository/ScanRepository.java
+++ b/backend/src/main/java/kg16/demo/repository/ScanRepository.java
@@ -1,0 +1,21 @@
+package kg16.demo.repository;
+
+import kg16.demo.model.Scan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+@Repository
+public interface ScanRepository extends JpaRepository<Scan, Long> {
+
+    Optional<Scan> findByMacAddress(String macAddress);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Scan s SET s.ipAddress = :ip, s.hostname = :hostname, s.status = :status, s.lastSeen = CURRENT_TIMESTAMP WHERE s.macAddress = :mac")
+    int updateScan(@Param("mac") String macAddress, @Param("ip") String ipAddress, @Param("hostname") String hostname, @Param("status") Integer status);
+}

--- a/backend/src/main/java/kg16/demo/repository/ScanRepository.java
+++ b/backend/src/main/java/kg16/demo/repository/ScanRepository.java
@@ -16,6 +16,18 @@ public interface ScanRepository extends JpaRepository<Scan, Long> {
 
     @Modifying
     @Transactional
-    @Query("UPDATE Scan s SET s.ipAddress = :ip, s.hostname = :hostname, s.status = :status, s.lastSeen = CURRENT_TIMESTAMP WHERE s.macAddress = :mac")
-    int updateScan(@Param("mac") String macAddress, @Param("ip") String ipAddress, @Param("hostname") String hostname, @Param("status") Integer status);
+    @Query("""
+        UPDATE Scan s 
+        SET s.ipAddress = :ip, 
+        s.hostname = :hostname, 
+        s.status = :status, 
+        s.lastSeen = CURRENT_TIMESTAMP WHERE 
+        s.macAddress = :mac
+        """)
+    int updateScan(
+        @Param("mac") String macAddress, 
+        @Param("ip") String ipAddress, 
+        @Param("hostname") String hostname, 
+        @Param("status") Integer status
+        );
 }

--- a/backend/src/main/java/kg16/demo/web/ScanController.java
+++ b/backend/src/main/java/kg16/demo/web/ScanController.java
@@ -1,0 +1,34 @@
+package kg16.demo.web;
+
+import kg16.demo.model.Scan;
+import kg16.demo.repository.ScanRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Optional;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.sql.Timestamp;
+
+@RestController
+@RequestMapping("/api/scans")
+public class ScanController {
+
+    @Autowired
+    private ScanRepository scanRepository;
+
+    @PostMapping("/add")
+    public ResponseEntity<String> addOrUpdateScan(@RequestBody Scan scan) {
+        Optional<Scan> existingScan = scanRepository.findByMacAddress(scan.getMacAddress());
+    
+        if (existingScan.isPresent()) {
+            scanRepository.updateScan(scan.getMacAddress(), scan.getIpAddress(), scan.getHostname(), scan.getStatus());
+            return ResponseEntity.ok("Updated scan for MAC: " + scan.getMacAddress());
+        } else {
+            scan.setLastSeen(new Timestamp(System.currentTimeMillis()));
+            scanRepository.save(scan);
+            return ResponseEntity.ok("Inserted new scan for MAC: " + scan.getMacAddress());
+        }
+    }
+    
+}
+

--- a/backend/src/main/java/kg16/demo/web/ScanController.java
+++ b/backend/src/main/java/kg16/demo/web/ScanController.java
@@ -1,13 +1,14 @@
 package kg16.demo.web;
 
+import kg16.demo.dto.ScanDTO;
 import kg16.demo.model.Scan;
 import kg16.demo.repository.ScanRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import java.util.Optional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.sql.Timestamp;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/scans")
@@ -17,18 +18,27 @@ public class ScanController {
     private ScanRepository scanRepository;
 
     @PostMapping("/add")
-    public ResponseEntity<String> addOrUpdateScan(@RequestBody Scan scan) {
-        Optional<Scan> existingScan = scanRepository.findByMacAddress(scan.getMacAddress());
-    
+    public ResponseEntity<String> addOrUpdateScan(@RequestBody ScanDTO scanDTO) {
+        Optional<Scan> existingScan = scanRepository.findByMacAddress(scanDTO.getMacAddress());
+
         if (existingScan.isPresent()) {
-            scanRepository.updateScan(scan.getMacAddress(), scan.getIpAddress(), scan.getHostname(), scan.getStatus());
-            return ResponseEntity.ok("Updated scan for MAC: " + scan.getMacAddress());
+            scanRepository.updateScan(
+                scanDTO.getMacAddress(),
+                scanDTO.getIpAddress(),
+                scanDTO.getHostname(),
+                scanDTO.getStatus()
+            );
+            return ResponseEntity.ok("Updated scan for MAC: " + scanDTO.getMacAddress());
         } else {
-            scan.setLastSeen(new Timestamp(System.currentTimeMillis()));
-            scanRepository.save(scan);
-            return ResponseEntity.ok("Inserted new scan for MAC: " + scan.getMacAddress());
+            Scan newScan = new Scan(
+                scanDTO.getHostname(),
+                scanDTO.getIpAddress(),
+                scanDTO.getMacAddress(),
+                scanDTO.getStatus(),
+                new Timestamp(System.currentTimeMillis())  // Set last seen to now
+            );
+            scanRepository.save(newScan);
+            return ResponseEntity.ok("Inserted new scan for MAC: " + scanDTO.getMacAddress());
         }
     }
-    
 }
-


### PR DESCRIPTION
This PR adds storing results from scan into database via spring boot API.

Spring Boot API Recieves scan result via /api/scans/add updating the database.
It stores the devices in the database or updates excisting posts with new data.

How it works:
Python script scans the network and extract active devices
Sends result to the backend API
API updates data for existing devices or inserts new ones

closes #7 